### PR TITLE
Fix reference to library.

### DIFF
--- a/FreeFlowTestsStub/project.properties
+++ b/FreeFlowTestsStub/project.properties
@@ -1,12 +1,12 @@
 #-------------------------------------------------------------------------------
 # Copyright 2013 Comcast Cable Communications Management, LLC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,4 +27,4 @@
 
 # Project target.
 target=android-16
-android.library.reference.1=../CollectionViews2
+android.library.reference.1=../FreeFlow


### PR DESCRIPTION
This allows `ant clean debug` to be run from the root.

```
$ ant clean debug | tail -2
BUILD SUCCESSFUL
Total time: 42 seconds
```
