### PR TITLE
fix to allow usage of the OnItemLongClickListener when the choise mode i...

### DIFF
--- a/FreeFlow/src/com/comcast/freeflow/core/FreeFlowContainer.java
+++ b/FreeFlow/src/com/comcast/freeflow/core/FreeFlowContainer.java
@@ -1675,6 +1675,14 @@ public class FreeFlowContainer extends AbsLayoutContainer {
 				int position, long id, boolean checked);
 	}
 
+	@Override
+	public void setOnItemLongClickListener(OnItemLongClickListener listener) {
+		super.setOnItemLongClickListener(listener);
+		if (mCheckStates==null) {
+			mCheckStates = new SimpleArrayMap<IndexPath, Boolean>(); 
+		}
+	}
+	
 	public void setItemChecked(int sectionIndex, int positionInSection,
 			boolean value) {
 		if (mChoiceMode == CHOICE_MODE_NONE) {


### PR DESCRIPTION
fix to allow usage of the OnItemLongClickListener when the choise mode is set to FreeFlowContainer.CHOICE_MODE_NONE