### PR TITLE
Fix crash when getScaledOverflingDistance() == 0

### DIFF
--- a/FreeFlow/build.gradle
+++ b/FreeFlow/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.14.4'
+        classpath 'com.android.tools.build:gradle:1.1.0'
     }
 }
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 repositories {
     mavenLocal()

--- a/FreeFlow/src/com/comcast/freeflow/core/FreeFlowContainer.java
+++ b/FreeFlow/src/com/comcast/freeflow/core/FreeFlowContainer.java
@@ -1261,7 +1261,7 @@ public class FreeFlowContainer extends AbsLayoutContainer {
 				viewPortY = (int) (mScrollableHeight + overflingDistance);
 			}
 
-			if (mEdgeEffectsEnabled) {
+			if (mEdgeEffectsEnabled && overflingDistance > 0) {
 				if (viewPortX <= 0) {
 					mLeftEdge.onPull(viewPortX / (-overflingDistance));
 				} else if (viewPortX >= mScrollableWidth) {

--- a/examples/Artbook/build.gradle
+++ b/examples/Artbook/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.14.4'
+    classpath 'com.android.tools.build:gradle:1.1.0'
   }
 }
 
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
   compile project(':FreeFlow')

--- a/examples/PhotoGrid/build.gradle
+++ b/examples/PhotoGrid/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.14.4'
+    classpath 'com.android.tools.build:gradle:1.1.0'
   }
 }
 
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
   compile project(':FreeFlow')


### PR DESCRIPTION
We encounted crash on calculation of edge effects.
Divide by zero on below line.

```java
mLeftEdge.onPull(viewPortX / (-overflingDistance));
```

http://crashes.to/s/1f8091cd688

N-03E, device sold in Japan with "Disney Mobile on docomo" brand,
seems to return 0 for `connfiguration.getScaledOverflingDistance()`
This can be done with customizing this constant of ViewConfiguration: http://tools.oesf.biz/android-4.0.4_r1.0/xref/frameworks/base/core/java/android/view/ViewConfiguration.java#224 .

Possible fix was on https://github.com/Comcast/FreeFlow/commit/003e8fc486f567b42881bec5770c2384c73d3924#diff-e7d010dace6714a20e845b07ba789fa6R1027 ,
but it was removed on https://github.com/Comcast/FreeFlow/commit/60c56fe0e9f644f979d84ebcdd190a042658257c#diff-c38b0300174165db5f03f319b3a71847L1122 .

Thanks!