### PR TITLE
Invoking Scroll Listeners inside moveViewport

### DIFF
--- a/FreeFlow/src/com/comcast/freeflow/core/FreeFlowContainer.java
+++ b/FreeFlow/src/com/comcast/freeflow/core/FreeFlowContainer.java
@@ -1025,7 +1025,6 @@ public class FreeFlowContainer extends AbsLayoutContainer {
 
 		if (mTouchMode == TOUCH_MODE_SCROLL) {
 			moveViewportBy(event.getX() - deltaX, event.getY() - deltaY, false);
-			invokeOnItemScrollListeners();
 			deltaX = event.getX();
 			deltaY = event.getY();
 		}
@@ -1300,7 +1299,7 @@ public class FreeFlowContainer extends AbsLayoutContainer {
 		}
 
 		invalidate();
-
+		invokeOnItemScrollListeners();
 	}
 
 	protected boolean mEdgeEffectsEnabled = true;
@@ -1883,7 +1882,6 @@ public class FreeFlowContainer extends AbsLayoutContainer {
 			post(flingRunnable);
 		} else {
 			moveViewportBy((viewPortX - newVPX), (viewPortY - newVPY), false);
-			invokeOnItemScrollListeners();
 		}
 	}
 


### PR DESCRIPTION
We are missing some feedback on scrolling while on fling mode, to fix it, scroll listeners should be invoked inside moveViewport
